### PR TITLE
Enable preview always

### DIFF
--- a/sltv/sltv.py
+++ b/sltv/sltv.py
@@ -443,10 +443,9 @@ class Sltv(gobject.GObject):
 
                     gst.element_link_many(self.audio_tee, audio_queue, encoder)
 
-        if self.preview_enabled:
-            self.preview = Preview(self)
-            self.player.add(self.preview)
-            self.preview_tee.get_src_pad().link(self.preview.sink_pads().next())
+        self.preview = Preview(self)
+        self.player.add(self.preview)
+        self.preview_tee.get_src_pad().link(self.preview.sink_pads().next())
 
         if pip_width == 0:
             pip_width = 320

--- a/sltv/ui/preview.py
+++ b/sltv/ui/preview.py
@@ -29,8 +29,6 @@ class PreviewUI:
         self.interface = gtk.Builder()
         self.interface.add_from_file(UI_DIR + "/preview.ui")
         self.widget = self.interface.get_object("vbox")
-        self.button = self.interface.get_object("preview_checkbutton")
-        self.button.connect("toggled", self.toggled)
         self.preview_state = False
         sltv.set_preview(self.preview_state)
     def toggled(self, checkbox):

--- a/ui/preview.ui
+++ b/ui/preview.ui
@@ -7,19 +7,5 @@
     <property name="border_width">1</property>
     <property name="orientation">vertical</property>
     <property name="spacing">10</property>
-    <child>
-      <object class="GtkCheckButton" id="preview_checkbutton">
-        <property name="label" translatable="yes">Enable preview</property>
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">False</property>
-        <property name="draw_indicator">True</property>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">False</property>
-        <property name="position">1</property>
-      </packing>
-    </child>
   </object>
 </interface>


### PR DESCRIPTION
In practice, preview is always used, so no need to add more
configurations to the UI or the pipeline.

Part of this patch was contributed by Armando Taffarel
taffarel@solis.com.br.
